### PR TITLE
Add CLAUDE.md and replace boilerplate README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev      # Start dev server with Turbopack at localhost:3000
+npm run build    # Production build (outputs static site to ./out)
+npm run lint     # ESLint
+```
+
+No test suite exists.
+
+## Architecture
+
+Single-page Next.js 15 app deployed as a static site to GitHub Pages (via `.github/workflows/nextjs.yml` on push to `main`). All sections are on one scrollable page — there are no sub-routes.
+
+**Page assembly** (`src/app/page.jsx`):
+- `Header` (desktop-only, hide-on-scroll)
+- `Content` — the main section container
+- `Footer`
+
+**Content sections** (`src/app/sections/Content.jsx`) render in order:
+1. `Greeting` / `GreetingMobile` — hero, responsive swap at `lg` breakpoint
+2. `AboutAFK`
+3. `InfoBeforeFair` OR `InfoFair` — swap these manually depending on proximity to the event date (see comment in Content.jsx)
+4. `Organizers`
+5. `Participants` — **currently commented out**, pending company approval
+6. `Contact` (includes `ContactForm`)
+
+**Components** live in `src/app/components/`:
+- `content/` — feature-specific (greeting, participants, event-info, contact)
+- `ui/` — small reusable primitives (ButtonHeader, ButtonLink, ButtonSocials, Countdown, ImageText, Link)
+
+**Data**: Participating companies are stored in `src/app/json/companies.json` and consumed by the `Participants` component. There's also `test-companies.json` for development.
+
+**Contact form** (`ContactForm.jsx`) posts JSON to `https://contactapi.afk-fair.com/contact` and uses Cloudflare Turnstile for bot protection (sitekey in the component, script loaded dynamically).
+
+## Styling
+
+Tailwind CSS + custom `afk-*` utility classes defined in `src/app/globals.css`. Always prefer the existing `afk-*` classes (`afk-card`, `afk-title`, `afk-section-title`, `afk-pill`, `afk-link`, `afk-divider`, `afk-orb`, `afk-outline`) over ad-hoc inline styles for consistency.
+
+Custom Tailwind theme values (see `tailwind.config.mjs`):
+- Colors: `primary` (#92C7FF), `secondary` (#4d98e8), `participant` (blue overlay)
+- Fonts: `font-sans` → Chakra Petch, `font-serif` → Josefin Sans
+- Animation: `appear` (fade-in, 2s ease-in-out)
+
+CSS variables for the color palette are in `:root` in `globals.css` (`--afk-blue`, `--afk-ink`, `--afk-paper`, `--afk-muted`, etc.).

--- a/README.md
+++ b/README.md
@@ -1,36 +1,91 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# AFK Website
 
-## Getting Started
+The official website for AFK (Arbetslivskontakt vid Åbo Akademi), a career fair organized by [DATE](https://datateknologerna.com) — the student association for IT students at Åbo Akademi University.
 
-First, run the development server:
+## Development
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
+npm run dev      # Start dev server at localhost:3000 (uses Turbopack)
+npm run build    # Production build (static export to ./out)
+npm run lint     # ESLint
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Project Structure
 
-You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
+```
+src/app/
+├── layout.jsx              # Root layout (fonts, meta, CSP headers)
+├── page.jsx                # Entry point — assembles Header, Content, Footer
+├── globals.css             # Global styles and afk-* utility classes
+├── sections/
+│   ├── Header.jsx          # Desktop sticky nav (hidden on mobile)
+│   ├── HeaderMobile.jsx    # Mobile nav
+│   ├── Footer.jsx
+│   └── Content.jsx         # Main section container
+├── components/
+│   ├── content/            # Feature sections (greeting, event-info, participants, contact)
+│   └── ui/                 # Reusable primitives (buttons, countdown, links)
+└── json/
+    └── companies.json      # Participating company data for the Participants section
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Styling
 
-## Learn More
+Tailwind CSS is used alongside a set of custom `afk-*` classes defined in `globals.css`. Prefer these over ad-hoc Tailwind utilities for consistency:
 
-To learn more about Next.js, take a look at the following resources:
+| Class | Purpose |
+|---|---|
+| `afk-card` | Section card with dark background and blue border |
+| `afk-title` | Chakra Petch bold heading |
+| `afk-section-title` | Uppercase spaced section heading |
+| `afk-pill` | Rounded bordered label/badge |
+| `afk-link` | Styled anchor |
+| `afk-divider` | Horizontal gradient rule |
+| `afk-orb` | Circular orb element |
+| `afk-outline` | Transparent text with stroke |
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Custom Tailwind colors: `primary` (#92C7FF), `secondary` (#4d98e8).
+Fonts: **Chakra Petch** (headings/UI) and **Josefin Sans** (body).
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Content Management
 
-## Deploy on Vercel
+### Switching event-info section
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+`Content.jsx` has two mutually exclusive components for the info section. Swap the comment around the one you want active based on how close the event is:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- **`<InfoBeforeFair />`** — show when the fair is more than ~2 months away (pricing, sign-up)
+- **`<InfoFair />`** — show when the fair is imminent (schedule, logistics)
+
+### Enabling the Participants section
+
+The `<Participants />` block in `Content.jsx` is commented out until companies have given approval to be listed. Uncomment it when ready. Company data is in `src/app/json/companies.json`:
+
+```json
+{
+  "companies": [
+    {
+      "id": 1,
+      "name": "Company Name",
+      "description": "...",
+      "logo": "/images/logos/logo.png"
+    }
+  ]
+}
+```
+
+Use `src/app/json/test-companies.json` as a reference for testing the layout with multiple entries.
+
+## Contact Form
+
+The contact form (`ContactForm.jsx`) uses [Cloudflare Turnstile](https://www.cloudflare.com/products/turnstile/) for bot protection and posts to an external API:
+
+```
+POST https://contactapi.afk-fair.com/contact
+```
+
+The Turnstile script is loaded dynamically on the client. The sitekey is hardcoded in `ContactForm.jsx`.
+
+## Deployment
+
+Every push to `main` triggers the GitHub Actions workflow (`.github/workflows/nextjs.yml`), which builds the static site and deploys it to GitHub Pages.


### PR DESCRIPTION
## Summary

- Replaces the default Next.js boilerplate README with project-specific documentation covering dev setup, project structure, styling conventions, content management (InfoBeforeFair/InfoFair swap, enabling Participants), and deployment
- Adds CLAUDE.md with architecture notes and command reference for AI-assisted development

## Test plan

- [ ] README renders correctly on GitHub
- [ ] CLAUDE.md renders correctly on GitHub